### PR TITLE
Tweaked to be n-dimensions

### DIFF
--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -136,11 +136,30 @@ def grid_from_domain(domain):
         axis in the input frame.
         [{'lower': float, 'upper': float, 'includes_lower': bool, 'includes_upper': bool, 'step': float}]
 
+    The assumption is the list is in order of X, Y [, Z] and the output will be in the same order.
+
+    For example, if the domain is [{'lower': 0, 'upper': 1623}, {'lower': 785, 'upper': 835}] then the output will be:
+
+    array([[[   0,    1,    2, ..., 1620, 1621, 1622],
+        [   0,    1,    2, ..., 1620, 1621, 1622],
+        [   0,    1,    2, ..., 1620, 1621, 1622],
+        ...,
+        [   0,    1,    2, ..., 1620, 1621, 1622],
+        [   0,    1,    2, ..., 1620, 1621, 1622],
+        [   0,    1,    2, ..., 1620, 1621, 1622]],
+
+       [[ 785,  785,  785, ...,  785,  785,  785],
+        [ 786,  786,  786, ...,  786,  786,  786],
+        [ 787,  787,  787, ...,  787,  787,  787],
+        ...,
+        [ 832,  832,  832, ...,  832,  832,  832],
+        [ 833,  833,  833, ...,  833,  833,  833],
+        [ 834,  834,  834, ...,  834,  834,  834]]])
+
     Returns
     -------
     x, y : ndarray
         Input points.
     """
     slices = [_get_slice(d) for d in domain]
-    y, x = np.mgrid[slices[::-1]]
-    return x, y
+    return np.mgrid[slices[::-1]][::-1]


### PR DESCRIPTION
I made a small tweak so that it will work in n-dimensions.

@nden and I also did some checks to make sure it is producing the expected output.

An example we did was using a domain of:

```
w1.domain = [{'lower': 0, 'upper': 1623},
 {'lower': 785, 'upper': 835}]
```

The output of the new function was:

```
array([[[   0,    1,    2, ..., 1620, 1621, 1622],
        [   0,    1,    2, ..., 1620, 1621, 1622],
        [   0,    1,    2, ..., 1620, 1621, 1622],
        ...,
        [   0,    1,    2, ..., 1620, 1621, 1622],
        [   0,    1,    2, ..., 1620, 1621, 1622],
        [   0,    1,    2, ..., 1620, 1621, 1622]],

       [[ 785,  785,  785, ...,  785,  785,  785],
        [ 786,  786,  786, ...,  786,  786,  786],
        [ 787,  787,  787, ...,  787,  787,  787],
        ...,
        [ 832,  832,  832, ...,  832,  832,  832],
        [ 833,  833,  833, ...,  833,  833,  833],
        [ 834,  834,  834, ...,  834,  834,  834]]])
```

Which makes sense given what we worked out on paper. 

I modified the w1.domain to be 3d:

```
In [51]: w1 = nirspec.nrs_wcs_set_input(a, 0, slice)

In [52]: w1.domain.append( {'lower': 4, 'upper': 7} )

In [53]: w1.domain
Out[53]:
[{'lower': 0, 'upper': 1623},
 {'lower': 785, 'upper': 835},
 {'lower': 4, 'upper': 7}]

In [54]: gfd_grid = grid_from_domain(w1.domain)

In [55]: gfd_grid
Out[55]:
array([[[[   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622],
         ...,
         [   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622]],

        [[   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622],
         ...,
         [   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622]],

        [[   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622],
         ...,
         [   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622],
         [   0,    1,    2, ..., 1620, 1621, 1622]]],


       [[[ 785,  785,  785, ...,  785,  785,  785],
         [ 786,  786,  786, ...,  786,  786,  786],
         [ 787,  787,  787, ...,  787,  787,  787],
         ...,
         [ 832,  832,  832, ...,  832,  832,  832],
         [ 833,  833,  833, ...,  833,  833,  833],
         [ 834,  834,  834, ...,  834,  834,  834]],

        [[ 785,  785,  785, ...,  785,  785,  785],
         [ 786,  786,  786, ...,  786,  786,  786],
         [ 787,  787,  787, ...,  787,  787,  787],
         ...,
         [ 832,  832,  832, ...,  832,  832,  832],
         [ 833,  833,  833, ...,  833,  833,  833],
         [ 834,  834,  834, ...,  834,  834,  834]],

        [[ 785,  785,  785, ...,  785,  785,  785],
         [ 786,  786,  786, ...,  786,  786,  786],
         [ 787,  787,  787, ...,  787,  787,  787],
         ...,
         [ 832,  832,  832, ...,  832,  832,  832],
         [ 833,  833,  833, ...,  833,  833,  833],
         [ 834,  834,  834, ...,  834,  834,  834]]],


       [[[   4,    4,    4, ...,    4,    4,    4],
         [   4,    4,    4, ...,    4,    4,    4],
         [   4,    4,    4, ...,    4,    4,    4],
         ...,
         [   4,    4,    4, ...,    4,    4,    4],
         [   4,    4,    4, ...,    4,    4,    4],
         [   4,    4,    4, ...,    4,    4,    4]],

        [[   5,    5,    5, ...,    5,    5,    5],
         [   5,    5,    5, ...,    5,    5,    5],
         [   5,    5,    5, ...,    5,    5,    5],
         ...,
         [   5,    5,    5, ...,    5,    5,    5],
         [   5,    5,    5, ...,    5,    5,    5],
         [   5,    5,    5, ...,    5,    5,    5]],

        [[   6,    6,    6, ...,    6,    6,    6],
         [   6,    6,    6, ...,    6,    6,    6],
         [   6,    6,    6, ...,    6,    6,    6],
         ...,
         [   6,    6,    6, ...,    6,    6,    6],
         [   6,    6,    6, ...,    6,    6,    6],
         [   6,    6,    6, ...,    6,    6,    6]]]])

In [56]:
```

The output appears to make sense so this PR should be good.
